### PR TITLE
检查异步方法 & 补充生成代码的命名域

### DIFF
--- a/src/AutoWasmApi.Roslyn/HttpServiceInvokerGenerator.cs
+++ b/src/AutoWasmApi.Roslyn/HttpServiceInvokerGenerator.cs
@@ -280,7 +280,7 @@ namespace AutoWasmApiGenerator
             {
                 var p = bodyParameters.First().p;
                 statements.Add($"var _json_gen = global::System.Text.Json.JsonSerializer.Serialize({p.Name})");
-                statements.Add("""_request_gen.Content = new StringContent(_json_gen, global::System.Text.Encoding.Default, "application/json")""");
+                statements.Add("""_request_gen.Content = new global::System.Net.Http.StringContent(_json_gen, global::System.Text.Encoding.Default, "application/json")""");
             }
 
             #endregion
@@ -311,7 +311,7 @@ namespace AutoWasmApiGenerator
 
             #endregion
 
-            statements.Add("_request_gen.RequestUri = new Uri(_url_gen, UriKind.Relative)");
+            statements.Add("_request_gen.RequestUri = new global::System.Uri(_url_gen, UriKind.Relative)");
             var returnType = methodSymbol.ReturnType.GetGenericTypes().FirstOrDefault() ?? methodSymbol.ReturnType;
 
             if (methodSymbol.ReturnsVoid || returnType.ToDisplayString() == "System.Threading.Tasks.Task")

--- a/src/AutoWasmApi.Roslyn/HttpServiceInvokerGenerator.cs
+++ b/src/AutoWasmApi.Roslyn/HttpServiceInvokerGenerator.cs
@@ -118,6 +118,19 @@ namespace AutoWasmApiGenerator
                         .Lambda("throw new global::System.NotSupportedException()");
                 return (b, null);
             }
+
+            // 检查当前返回类型是否是Task或Task<T>
+            // 如果检查类型不符合要求，说明不是异步方法
+            // 返回错误信息
+            var returnTypeInfo = methodSymbol.ReturnType;
+            var isTask = returnTypeInfo.Name == "Task";
+            var isGenericTask = returnTypeInfo.OriginalDefinition.ToDisplayString() == "System.Threading.Tasks.Task<T>";
+
+            if (!isTask && !isGenericTask)
+            {
+                return (null, DiagnosticDefinitions.WAG00005(methodSymbol.Locations.FirstOrDefault()));
+            }
+
             string webMethod;
             if (!methodAttribute.GetNamedValue("Method", out var v))
             {


### PR DESCRIPTION
### 改进错误处理：

* 添加了检查，验证返回类型是否为 `Task` 或 `Task<T>`，如果方法不是异步的，则返回错误诊断信息。

### 完善生成的代码中使用的命名域：

* 使用`StringContent`的完全限定名 `global::System.Net.Http.StringContent`。
* 使用`Uri`完全限定名 `global::System.Uri`。